### PR TITLE
gh-10: angst.grf.compute using flt

### DIFF
--- a/docs/grf.rst
+++ b/docs/grf.rst
@@ -8,9 +8,8 @@
 Gaussian angular power spectra
 ------------------------------
 
+.. autofunction:: compute
 .. autofunction:: solve
-
-.. autofunction:: compute_generic
 
 
 Transformations


### PR DESCRIPTION
Implement a new function `angst.grf.compute()` that can compute a band-limited Gaussian angular power spectrum.

Still in draft while the `flt` package hasn't had a new release.