### PR TITLE
gh-16: add shotnoise() function

### DIFF
--- a/docs/bibliography.rst
+++ b/docs/bibliography.rst
@@ -1,0 +1,9 @@
+Bibliography
+============
+
+.. [arXiv:2408.16903] *Euclid preparation. LIX. Angular power spectra from
+   discrete observations*. Euclid Collaboration: N. Tessore, B. Joachimi, A.
+   Loureiro, et al. (2024). https://arxiv.org/pdf/2408.16903
+
+.. [arXiv:2507.03749] *Shot noise in clustering power spectra*. N. Tessore, A.
+   Hall (2025). https://arxiv.org/pdf/2507.03749

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@
    twopoint
    core
    glossary
+   bibliography
 
 
 Indices and tables

--- a/docs/twopoint.rst
+++ b/docs/twopoint.rst
@@ -13,6 +13,15 @@ Spectra and correlation functions
 .. autofunction:: cl2var
 
 
+Shot noise bias
+---------------
+
+Compute the value of the shot noise bias contribution to angular power spectra.
+For reference, see [arXiv:2408.16903]_ and [arXiv:2507.03749]_.
+
+.. autofunction:: shotnoise
+
+
 Sets of two-point functions
 ---------------------------
 

--- a/src/angst/__init__.py
+++ b/src/angst/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "enumerate2",
     "inv_triangle_number",
     "indices2",
+    "shotnoise",
 ]
 
 from ._core import (
@@ -21,6 +22,7 @@ from ._twopoint import (
     corr2cl,
     enumerate2,
     indices2,
+    shotnoise,
 )
 
 from ._version import (


### PR DESCRIPTION
Add a `angst.shotnoise()` function to compute the shot noise contribution.

Closes: #16